### PR TITLE
Fix EOFError when using a block to get the http response

### DIFF
--- a/lib/evostream/client.rb
+++ b/lib/evostream/client.rb
@@ -38,11 +38,7 @@ module Evostream
 
     def api_call(method, params)
       url = URI.parse(service_url(method, params))
-      request = Net::HTTP::Get.new(url.to_s)
-      response = Net::HTTP.start(url.host, url.port) {|http|
-        http.request(request)
-      }
-      response
+      Net::HTTP.get_response(url)
     end
 
     def service_url(service, params)


### PR DESCRIPTION
When I tried your gem on my application, using a block to get the response was giving me an EOFError when I tried to communicate with the evostream server, using a get_response call instead of a block fixes that error.
