### PR TITLE
Use urlsafe to encode Base64

### DIFF
--- a/lib/evostream/client.rb
+++ b/lib/evostream/client.rb
@@ -59,7 +59,7 @@ module Evostream
     end
 
     def encode_params(params)
-      Base64.encode64(params.map {|k, v| "#{k}=#{v}" }.join(' ')).chomp
+      Base64.urlsafe_encode64(params.map {|k, v| "#{k}=#{v}" }.join(' ')).chomp
     end
 
     def parse(text)


### PR DESCRIPTION
Using urlsafe_encode64 method instead of encode64 on Base64, this allows to use longer param values since line feeds are added to every 60 encoded characters.
