### PR TITLE
Support for http basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Evostream.configure do |config|
   config.host = 'evostream.example.com'
   config.port = 80
   config.path_prefix = '/evo'
+
+  # Set the username and password when using http basic auth
+  # config.username = 'evostream'
+  # config.password = 'passw0rd'
 end
 
 # elsewhere

--- a/lib/evostream/client.rb
+++ b/lib/evostream/client.rb
@@ -38,7 +38,9 @@ module Evostream
 
     def api_call(method, params)
       url = URI.parse(service_url(method, params))
-      Net::HTTP.get_response(url)
+      req = Net::HTTP::Get.new(url)
+      req.basic_auth(@username, @password)
+      Net::HTTP.start(url.hostname, url.port) { |http| http.request(req) }
     end
 
     def service_url(service, params)

--- a/lib/evostream/configuration.rb
+++ b/lib/evostream/configuration.rb
@@ -1,11 +1,13 @@
 # coding: utf-8
 module Evostream
   module Configuration
-    VALID_CONFIG_KEYS = [:host, :port, :path_prefix].freeze
+    VALID_CONFIG_KEYS = [:host, :port, :path_prefix, :username, :password].freeze
     OPTIONAL_CONFIG_KEYS = VALID_CONFIG_KEYS - [:host]
 
     DEFAULT_PORT = 80
     DEFAULT_PATH_PREFIX = ''
+    DEFAULT_USERNAME = ''
+    DEFAULT_PASSWORD = ''
 
     # Build accessor methods for every config options so we can do this, for example:
     #   Evostream.host = 'evostream.example.com'
@@ -19,6 +21,8 @@ module Evostream
     def reset
       self.port        = DEFAULT_PORT
       self.path_prefix = DEFAULT_PATH_PREFIX
+      self.username    = DEFAULT_USERNAME
+      self.password    = DEFAULT_PASSWORD
     end
 
     # config/initializers/evostream.rb (for instance)
@@ -27,6 +31,8 @@ module Evostream
     #   config.host = 'evostream.example.com'
     #   config.port = 80
     #   config.path_prefix = '/evo'
+    #   config.username = 'evo'
+    #   config.password = 'password'
     # end
     #
     # elsewhere

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -63,4 +63,17 @@ describe Evostream::Client do
     subject.some_service(:first_param => 'xxx', :second_param => 'xxx', :third_param => 'xxx')
     WebMock.should have_requested(:get, "http://somehost:80/some_path/some_service?params=Zmlyc3RfcGFyYW09eHh4IHNlY29uZF9wYXJhbT14eHggdGhpcmRfcGFyYW09eHh4")
   end
+
+  it "should encode the username and the password to support basic auth" do
+    auth_evo = Evostream::Client.new({
+      :host => 'somehost',
+      :path_prefix => '/some_path',
+      :username => 'user',
+      :password => 'password'
+    })
+    stub_request(:get, /.*some_service.*/).
+      to_return(status: 200, body: '{"data":null,"description":"","status":"SUCCESS"}')
+    auth_evo.some_service(:first_param => 'xxx', :second_param => 'xxx', :third_param => 'xxx')
+    WebMock.should have_requested(:get, "http://user:password@somehost:80/some_path/some_service?params=Zmlyc3RfcGFyYW09eHh4IHNlY29uZF9wYXJhbT14eHggdGhpcmRfcGFyYW09eHh4")
+  end
 end


### PR DESCRIPTION
When using Apache as a proxy, the API can be protected by http basic auth, this adds support for it.